### PR TITLE
Remove slug task from `build`

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -33,9 +33,6 @@
     (comp (sass)
           (global-metadata)
           (markdown :options {:extensions {:smarts true}})
-          (slug
-            :slug-fn (fn [_ m]
-              (:short-filename m)))
           (permalink)
           (print-meta)
           (render :renderer 'io.perun.site/guide-page :filterer guide?)


### PR DESCRIPTION
The result of this `:slug-fn` is the same as the file's existing
`:slug`. `:short-filename` is now always the same value as `:slug`.