### PR TITLE
add sentence about missing src directory

### DIFF
--- a/resources/guides/getting-started.md
+++ b/resources/guides/getting-started.md
@@ -113,6 +113,9 @@ Tasks:   add-repo                    Add all files in project git repo to filese
          yaml-metadata               Parse YAML metadata at the beginning of files
 ```
 
+In case Boot complains about a missing `src` directory, you can create
+one by running `mkdir src` and then re-run `boot --help`.
+
 The part below the `[...]` has been added to the set of available
 tasks by the code we put into our `build.boot` file and are part of
 [Perun][perun], the static site generator we will use in this guide.


### PR DESCRIPTION
Hey there!
While following your getting started guide I got an error while trying to run `boot --help`. I could solve it by creating an empty `src` folder. 
Not sure if this is just me with my setup or something that could happen to anyone.
In any case I thought it might be nice to add this to the guide in case newcomers struggle with that :)
FWIW here is the start of the error message

```
clojure.lang.ExceptionInfo: src
    data: {:file "/tmp/boot.user7050040376643075544.clj", :line 5}
java.nio.file.NoSuchFileException: src
    file: "src"
       sun.nio.fs.UnixException.translateToIOException                UnixException.java:   86
         sun.nio.fs.UnixException.rethrowAsIOException                UnixException.java:  102
         sun.nio.fs.UnixException.rethrowAsIOException                UnixException.java:  107
sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes       UnixFileAttributeViews.java:   55
      sun.nio.fs.UnixFileSystemProvider.readAttributes       UnixFileSystemProvider.java:  144
     sun.nio.fs.LinuxFileSystemProvider.readAttributes      LinuxFileSystemProvider.java:   99
```