### PR TITLE
Update to latest snapshot

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -46,7 +46,7 @@
   []
   (comp (sass)
         (global-metadata)
-        (markdown :options {:extensions {:smarts true :extanchorlinks true}})
+        (markdown :md-exts {:smarts true :extanchorlinks true})
         (header-links)
         (permalink)
         (print-meta)


### PR DESCRIPTION
There were a few things in `build.boot` that needed updating to work with the latest `0.4.2-SNAPSHOT` version of perun.